### PR TITLE
Alternative way to implement MigrationAwareInterface

### DIFF
--- a/MigrationAwareTrait.php
+++ b/MigrationAwareTrait.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Damir Garifullin
+ * Date: 08.07.16
+ * Time: 13:36
+ */
+
+namespace indigerd\migrationaware;
+
+trait MigrationAwareTrait
+{
+    /**
+     * Returns migrations path of the module
+     *
+     * @return string
+     */
+    public function getMigrationPath()
+    {
+        $reflector = new \ReflectionClass(get_class($this));
+        return dirname($reflector->getFileName()) . "/migrations";
+    }
+}


### PR DESCRIPTION
Added MigrationAwareTrait which can be used instead of extendeing MigrationAwareModule

Example:

class Module extends \yii\base\Module implements MigrationAwareInterface
{
    use MigrationAwareTrait;
}
